### PR TITLE
Add project wiki

### DIFF
--- a/wiki/BluetoothProtocol.md
+++ b/wiki/BluetoothProtocol.md
@@ -1,0 +1,21 @@
+# Bluetooth Protocol
+
+The project includes a small BLE protocol layer. The commands are displayed in the `BluetoothProtocol` component and are intended for a hypothetical TP‑Dispenser device.
+
+Supported commands:
+
+- `DISPENSE:{sheets}` – dispense a specific number of sheets.
+- `CALIBRATE_DISPENSER` – calibrate the motor and sensors.
+- `GET_STATUS` – query the current status of the dispenser.
+- `RESET_MOTOR` – reset any motor fault conditions.
+- `TEST_DISPENSE:{count}` – run a short test dispensing sequence.
+
+In this codebase the commands are logged to the console. When integrating with real hardware you would transmit these strings over BLE.
+
+### Example sequence
+
+1. `CALIBRATE_DISPENSER` – run once when first connecting to level sensors.
+2. `DISPENSE:3` – dispense three sheets.
+3. `GET_STATUS` – confirm the motor state.
+
+Each command is a plain UTF‑8 string terminated with a newline character. A real implementation might send these over a characteristic write or a serial port. The project keeps things simple by printing them to the console.

--- a/wiki/Components.md
+++ b/wiki/Components.md
@@ -1,0 +1,38 @@
+# Component Reference
+
+This section outlines the custom React Native components found in the `components` directory.
+
+## AIAnalyzer
+File: `components/AIAnalyzer.tsx`
+
+Renders an animated spinner that simulates AI analysis. It displays the latest analysis result once complete. Accepts `isAnalyzing` and `analysisResult` props.
+
+## BluetoothManager
+File: `components/BluetoothManager.tsx`
+
+Handles connection status and dispatches commands to the BLE device. In this demo it merely simulates a connection and logs commands. It exposes callbacks for connection state and dispense events.
+
+## BluetoothProtocol
+File: `components/BluetoothProtocol.tsx`
+
+Lists available BLE protocol commands and provides quick calibration or test buttons. Useful when integrating with real hardware. The command list is static but illustrates a simple way to show protocol docs in-app.
+
+## DispenserController
+File: `components/DispenserController.tsx`
+
+Manages dispensing progress and animates a motor gear while sheets are dispensed. Shows current sheet count and motor status. When the progress completes it triggers a callback to update the parent screen.
+
+## RecordButton
+File: `components/RecordButton.tsx`
+
+An animated button that toggles recording. Uses spring animations for a tactile feel and displays an emoji-based label.
+
+## SoundWaveVisualizer
+File: `components/SoundWaveVisualizer.tsx`
+
+Creates concentric animated circles that pulse with the microphone amplitude during recording. The `amplitude` prop influences the scale of the waves.
+
+## TPDispenser
+File: `components/TPDispenser.tsx`
+
+Displays a simple toilet paper dispenser graphic. As dispensing occurs, the sheet height animates to visualize the amount being dispensed. This is purely visual – no actual toilet paper is wasted.

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,0 +1,13 @@
+# Toilet Smart AI Wiki
+
+Welcome to the wiki for **Toilet Smart AI** – a playful React Native application that controls a fictional toilet paper dispenser via Bluetooth. This wiki expands on the project README with additional context, component breakdowns and troubleshooting tips.
+
+## Contents
+
+- [Setup](Setup.md)
+- [Application Overview](Overview.md)
+- [Component Reference](Components.md)
+- [Bluetooth Protocol](BluetoothProtocol.md)
+- [Troubleshooting](Troubleshooting.md)
+
+Use the links above to learn how to get the app running, explore its architecture and understand the simulated BLE commands. The Troubleshooting page covers common issues.

--- a/wiki/Overview.md
+++ b/wiki/Overview.md
@@ -1,0 +1,21 @@
+# Application Overview
+
+Toilet Smart AI is a light‑hearted demonstration of a React Native app that pairs with a fictional BLE toilet paper dispenser. The app features two main screens:
+
+1. **Recording Screen (`app/index.tsx`)** – displays a pulsing sound wave visualizer and a record button. After recording, the user can proceed to the control screen.
+2. **Control Screen (`app/control.tsx`)** – performs fake AI analysis of the recorded sounds, recommends the number of sheets and communicates with the simulated dispenser over Bluetooth.
+
+Under the hood the project uses Expo Router for file‑based navigation and React Native Reanimated for animations. The Bluetooth logic is simulated, but the components are structured as if a real BLE connection is present.
+
+### Architecture
+
+Navigation is managed by [Expo Router](https://expo.dev/router) using the `_layout.tsx` entry point in the `app` directory. Each screen is a simple functional component written in TypeScript.
+
+All UI elements live in `components/` and are composed on the two screens:
+
+- **index.tsx** – records audio and transitions to the control screen when done.
+- **control.tsx** – orchestrates the AI analysis, dispenser controller and Bluetooth modules.
+
+The Bluetooth workflow is mocked in `BluetoothManager.tsx`, but the code mirrors how a real BLE integration might be organized. Data flows downward through props, keeping the screens themselves lightweight.
+
+The whimsical theme aside, the project demonstrates a typical React Native + Expo code structure with clear separation of screens, components and utilities. You can reuse these patterns in a serious project by swapping out the novelty graphics and placeholder commands.

--- a/wiki/Setup.md
+++ b/wiki/Setup.md
@@ -1,0 +1,26 @@
+# Setup
+
+This project requires **Node.js 18+** and **npm 9+**.
+
+After cloning the repository, install dependencies and start Expo:
+
+```bash
+npm install
+npx expo start
+```
+
+The Expo CLI offers options to run on Android, iOS or the web. Useful scripts include:
+
+- `npm run android` – start the Android emulator
+- `npm run ios` – start the iOS simulator
+- `npm run web` – run the web build
+- `npm run lint` – run ESLint (requires the Expo CLI)
+- `npm run build` – export a static web build
+- `npm run reset-project` – move the current `app` directory to `app-example` and create a minimal template
+
+You can also run `npx tsc --noEmit` at any time to perform a type check without building files.
+
+If `npm run lint` fails with an Expo configuration error, ensure the `eslint-config-expo` package is installed by running `npm install --save-dev eslint-config-expo`.
+
+When debugging mobile connectivity issues you may need to clear Expo's cache with `npx expo start -c`.
+

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -1,0 +1,20 @@
+# Troubleshooting
+
+This page collects a few common gotchas when running the demo.
+
+## Linting errors
+If `npm run lint` complains that it cannot find the `expo` config, make sure you have the `eslint-config-expo` package installed:
+
+```bash
+npm install --save-dev eslint-config-expo
+```
+
+## Expo fails to start
+Sometimes the Expo bundler gets into a bad state. Restart with cache clearing:
+
+```bash
+npx expo start -c
+```
+
+## "Device not connected" messages
+The Bluetooth implementation in this repo is simulated. If the app shows that no device is connected, it's working as expected. Real hardware support would require implementing the command transport in `BluetoothManager.tsx`.


### PR DESCRIPTION
## Summary
- add a `wiki` folder with markdown docs
- expand wiki docs with more information

## Testing
- `npm run lint` *(fails: couldn't find config "expo" to extend from)*
- `npx tsc --noEmit` *(fails: numerous TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68498e1a5b14832da9607d3170c4c06f